### PR TITLE
fix for statamic 2.6.0

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,2 +1,0 @@
-routes:
-  /: index


### PR DESCRIPTION
Referencing routes with no controller breaks in statamic 2.6.0